### PR TITLE
make custom attacking actions able to break custom windows

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -54,6 +54,9 @@ function check_mario_attacking(obj, mario)
             if mario.action == ACT_WALL_KICK_AIR then
                 return 2
             end
+            if  (mario.action & ACT_FLAG_CUSTOM_ACTION ~= 0) and (mario.action & ACT_FLAG_ATTACKING ~= 0) then
+                return 2
+            end
         end
     end
 


### PR DESCRIPTION
This change allows custom attacking actions to be able to break star road's breakable windows

Before this commit custom characters like the sonic in this pull request https://github.com/coop-deluxe/sm64coopdx/pull/1081 can't break some star road windows due to giving up vanilla actions. This pull request remedies that by allowing any custom attacking action to be used in place of vanilla actions for breaking said windows.